### PR TITLE
Fix per-entry Atom feed link

### DIFF
--- a/functions/ejs/rss.ejs
+++ b/functions/ejs/rss.ejs
@@ -26,7 +26,7 @@
     <title type="xhtml"><div xmlns="http://www.w3.org/1999/xhtml"><%- entry.title %></div></title>
     <published><%= entry.createdAt %></published>
     <updated><%= entry.updatedAt %></updated>
-    <link rel="alternate">https://web3isgoinggreat.com/web1#<%= entry.id %></link> 
+    <link href="https://web3isgoinggreat.com/web1#<%= entry.id %>"/> 
     <id>https://web3isgoinggreat.com/web1#<%= entry.id %></id>
     <content type="xhtml">
       <div xmlns="http://www.w3.org/1999/xhtml">


### PR DESCRIPTION
link tag requires an href="[url]" attribute rather than enclosing an URL
(and rel="alternate" is the default so not required)

https://validator.w3.org/feed/docs/atom.html#link