### PR TITLE
fix missing bullets

### DIFF
--- a/src/styles/main.sass
+++ b/src/styles/main.sass
@@ -481,7 +481,7 @@ dt
 
       &:not(:first-child):before
         color: $header-footer-body-color
-        content: "•" / ""
+        content: "•"
         padding: 10px
 
   .timeline-entry.single


### PR DESCRIPTION
The bullets are missing in Firefox, Safari and possibly other browsers.

<img width="568" alt="Zrzut ekranu 2022-01-3 o 16 57 53" src="https://user-images.githubusercontent.com/47485431/147951989-ac38d627-e65a-4ee5-9162-50fb031a8a39.png">
