### PR TITLE
Add popovers using popper.js

### DIFF
--- a/src/components/timeline/EnrichedBody.js
+++ b/src/components/timeline/EnrichedBody.js
@@ -1,13 +1,27 @@
-import React, { useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import PropTypes from "prop-types";
-import { Popover } from "react-tiny-popover";
+import { usePopper } from "react-popper";
 
 export default function EnrichedBody({ children, glossary }) {
   const [activeTarget, setActiveTarget] = useState(null);
+  const [popperElement, setPopperElement] = useState(null);
+  const { styles, attributes } = usePopper(activeTarget, popperElement);
+
+  const clickOff = useCallback((event) => {
+    if (!event.target.classList.contains("define-target")) {
+      document.removeEventListener("click", clickOff);
+      setActiveTarget(null);
+    }
+  }, []);
+
+  useEffect(() => {
+    return () => document.removeEventListener("click", clickOff);
+  }, [clickOff]);
 
   const callback = (event) => {
     if (event.target.classList.contains("define-target")) {
       setActiveTarget(event.target);
+      document.addEventListener("click", clickOff);
     }
   };
 
@@ -37,18 +51,24 @@ export default function EnrichedBody({ children, glossary }) {
   };
 
   return (
-    <Popover
-      content={renderPopoverContents}
-      isOpen={!!activeTarget}
-      onClickOutside={() => setActiveTarget(null)}
-      containerClassName="definition-popover"
-    >
+    <>
+      {activeTarget && (
+        <div
+          ref={setPopperElement}
+          style={{ ...styles.popper }}
+          {...attributes.popper}
+          className="definition-popover"
+        >
+          {renderPopoverContents()}
+        </div>
+      )}
+
       <span
         id="bodyContainer"
         dangerouslySetInnerHTML={{ __html: children }}
         onClick={callback}
       />
-    </Popover>
+    </>
   );
 }
 

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "web3-is-going-great",
       "dependencies": {
+        "@popperjs/core": "^2.11.2",
         "firebase": "^9.6.3",
         "moment": "^2.29.1",
         "next": "12.0.8",
@@ -13,9 +14,9 @@
         "react-dom": "17.0.2",
         "react-ga": "^3.3.0",
         "react-intersection-observer": "^8.33.1",
+        "react-popper": "^2.2.5",
         "react-query": "^3.34.8",
-        "react-select": "^5.2.2",
-        "react-tiny-popover": "^7.0.1"
+        "react-select": "^5.2.2"
       },
       "devDependencies": {
         "@fortawesome/fontawesome-free": "^6.0.0-beta3",
@@ -1618,6 +1619,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.2.tgz",
+      "integrity": "sha512-92FRmppjjqz29VMJ2dn+xdyXZBrMlE42AV6Kq6BwjWV7CNUW1hs2FtxSNLQE+gJhaZ6AAmYuO9y8dshhcBl7vA==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -4398,6 +4408,11 @@
         "react": "17.0.2"
       }
     },
+    "node_modules/react-fast-compare": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
+      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
+    },
     "node_modules/react-ga": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/react-ga/-/react-ga-3.3.0.tgz",
@@ -4419,6 +4434,19 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+    },
+    "node_modules/react-popper": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.2.5.tgz",
+      "integrity": "sha512-kxGkS80eQGtLl18+uig1UIf9MKixFSyPxglsgLBxlYnyDf65BiY9B3nZSc6C9XUNDgStROB0fMQlTEz1KxGddw==",
+      "dependencies": {
+        "react-fast-compare": "^3.0.1",
+        "warning": "^4.0.2"
+      },
+      "peerDependencies": {
+        "@popperjs/core": "^2.0.0",
+        "react": "^16.8.0 || ^17"
+      }
     },
     "node_modules/react-query": {
       "version": "3.34.8",
@@ -4466,15 +4494,6 @@
         "prop-types": "^15.6.0",
         "react-transition-group": "^4.3.0"
       },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0"
-      }
-    },
-    "node_modules/react-tiny-popover": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/react-tiny-popover/-/react-tiny-popover-7.0.1.tgz",
-      "integrity": "sha512-uV+nTZXkCtfPFQtoKwbfX8waaU7+b8LEOoyOUjtmRxqnH3KLX1FkPm7RU+RC8eXxtOe4rC1cuhOIbQFcc71vQQ==",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0",
         "react-dom": "^16.8.0 || ^17.0.0"
@@ -5144,6 +5163,14 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
       "dev": true
+    },
+    "node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
@@ -6633,6 +6660,11 @@
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
+    },
+    "@popperjs/core": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.2.tgz",
+      "integrity": "sha512-92FRmppjjqz29VMJ2dn+xdyXZBrMlE42AV6Kq6BwjWV7CNUW1hs2FtxSNLQE+gJhaZ6AAmYuO9y8dshhcBl7vA=="
     },
     "@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -8751,6 +8783,11 @@
         "scheduler": "^0.20.2"
       }
     },
+    "react-fast-compare": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
+      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
+    },
     "react-ga": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/react-ga/-/react-ga-3.3.0.tgz",
@@ -8767,6 +8804,15 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+    },
+    "react-popper": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.2.5.tgz",
+      "integrity": "sha512-kxGkS80eQGtLl18+uig1UIf9MKixFSyPxglsgLBxlYnyDf65BiY9B3nZSc6C9XUNDgStROB0fMQlTEz1KxGddw==",
+      "requires": {
+        "react-fast-compare": "^3.0.1",
+        "warning": "^4.0.2"
+      }
     },
     "react-query": {
       "version": "3.34.8",
@@ -8796,12 +8842,6 @@
         "prop-types": "^15.6.0",
         "react-transition-group": "^4.3.0"
       }
-    },
-    "react-tiny-popover": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/react-tiny-popover/-/react-tiny-popover-7.0.1.tgz",
-      "integrity": "sha512-uV+nTZXkCtfPFQtoKwbfX8waaU7+b8LEOoyOUjtmRxqnH3KLX1FkPm7RU+RC8eXxtOe4rC1cuhOIbQFcc71vQQ==",
-      "requires": {}
     },
     "react-transition-group": {
       "version": "4.4.2",
@@ -9276,6 +9316,14 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
       "dev": true
+    },
+    "warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "requires": {
+        "loose-envify": "^1.0.0"
+      }
     },
     "webidl-conversions": {
       "version": "3.0.1",

--- a/src/package.json
+++ b/src/package.json
@@ -8,6 +8,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@popperjs/core": "^2.11.2",
     "firebase": "^9.6.3",
     "moment": "^2.29.1",
     "next": "12.0.8",
@@ -15,9 +16,9 @@
     "react-dom": "17.0.2",
     "react-ga": "^3.3.0",
     "react-intersection-observer": "^8.33.1",
+    "react-popper": "^2.2.5",
     "react-query": "^3.34.8",
-    "react-select": "^5.2.2",
-    "react-tiny-popover": "^7.0.1"
+    "react-select": "^5.2.2"
   },
   "devDependencies": {
     "@fortawesome/fontawesome-free": "^6.0.0-beta3",

--- a/src/styles/_popovers.sass
+++ b/src/styles/_popovers.sass
@@ -41,24 +41,7 @@
   padding: 10px
   margin: 0
   display: block
-  position: absolute
   max-width: 400px
   width: 90%
   border: 1px solid rgba(0, 0, 0, 0.2)
   box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.4)
-  z-index: 2
-
-.definition-popover:after
-  position: absolute
-  bottom: -6px
-  left: 20px
-  background-color: $card-background
-  border: 0px solid rgba(0,0,0,0.2)
-  border-bottom-width: 1px
-  border-right-width: 1px
-  box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.2)
-  content: ' '
-  height: 10px
-  width: 10px
-  pointer-events: none
-  transform: rotate(45deg)


### PR DESCRIPTION
Hello! : )

Stumbled across the issue in https://github.com/molly/web3-is-going-great/pull/76 . If you're not set on `react-tiny-popover`, I think it might be easier to swap to `react-popper` based on the popular `popper.js` library as it lets you specify the DOM element to attach the popover to. Could benefit from a little tweaking on the CSS side, but the basics are there: 

<img width="1296" alt="Screen Shot 2022-02-02 at 4 06 18 pm" src="https://user-images.githubusercontent.com/21051488/152101744-95a2627b-1bbe-48cb-8b46-053bb567479f.png">
