### PR TITLE
Allow users to control grift counter direction, move settings to panel

### DIFF
--- a/src/components/timeline/FixedAtBottom.js
+++ b/src/components/timeline/FixedAtBottom.js
@@ -1,0 +1,34 @@
+import PropTypes from "prop-types";
+import useIsBrowserRendering from "../../hooks/useIsBrowserRendering";
+
+import ScrollToTop from "./ScrollToTop";
+import GriftCounter from "./GriftCounter";
+
+export default function FixedAtBottom({
+  headerInView,
+  shouldRenderGriftCounter,
+  scrollToTop,
+  currentRunningScamTotal,
+}) {
+  const isBrowserRendering = useIsBrowserRendering();
+
+  if (!isBrowserRendering) {
+    return null;
+  }
+
+  return (
+    <div className="fix-at-bottom">
+      {!headerInView && <ScrollToTop scrollToTop={scrollToTop} />}
+      {shouldRenderGriftCounter && (
+        <GriftCounter total={currentRunningScamTotal} />
+      )}
+    </div>
+  );
+}
+
+FixedAtBottom.propTypes = {
+  headerInView: PropTypes.bool.isRequired,
+  shouldRenderGriftCounter: PropTypes.bool.isRequired,
+  scrollToTop: PropTypes.func.isRequired,
+  currentRunningScamTotal: PropTypes.number.isRequired,
+};

--- a/src/components/timeline/FixedAtBottom.js
+++ b/src/components/timeline/FixedAtBottom.js
@@ -1,26 +1,124 @@
 import PropTypes from "prop-types";
+import { useState, useMemo, useCallback } from "react";
 import useIsBrowserRendering from "../../hooks/useIsBrowserRendering";
+
+import {
+  getLocalStorage,
+  LOCALSTORAGE_KEYS,
+  setLocalStorage,
+} from "../../js/localStorage";
 
 import ScrollToTop from "./ScrollToTop";
 import GriftCounter from "./GriftCounter";
+import SettingsPanel from "./SettingsPanel";
 
 export default function FixedAtBottom({
   headerInView,
   shouldRenderGriftCounter,
   scrollToTop,
-  currentRunningScamTotal,
+  runningGriftTotal,
+  griftTotal,
 }) {
   const isBrowserRendering = useIsBrowserRendering();
+  const prefersReducedMotion = useMemo(() => {
+    if (isBrowserRendering) {
+      const result = window.matchMedia("(prefers-reduced-motion: reduce)");
+      return result && result.matches;
+    }
+    return null;
+  }, [isBrowserRendering]);
+
+  const [isSettingsPanelShown, setIsSettingsPanelShown] = useState(false);
+  const [isGriftCounterExpanded, setIsGriftCounterExpanded] = useState(
+    getLocalStorage(LOCALSTORAGE_KEYS.griftCounterExpanded, true)
+  );
+  const [isGriftCounterCountingUp, setIsGriftCounterCountingUp] = useState(
+    getLocalStorage(LOCALSTORAGE_KEYS.griftCounterCountUp, true)
+  );
+  const [isAnimationPaused, setIsAnimationPaused] = useState(
+    getLocalStorage(LOCALSTORAGE_KEYS.flamesAnimationPaused, null) ||
+      prefersReducedMotion ||
+      null
+  );
+
+  const makeToggleFunction = useCallback(
+    (isToggledOn, toggleFn, localStorageKey = null) =>
+      () => {
+        if (isToggledOn) {
+          if (localStorageKey) {
+            setLocalStorage(localStorageKey, false);
+          }
+          toggleFn(false);
+        } else {
+          if (localStorageKey) {
+            setLocalStorage(localStorageKey, true);
+          }
+          toggleFn(true);
+        }
+      },
+    []
+  );
+
+  const toggleShowSettingsPanel = makeToggleFunction(
+    isSettingsPanelShown,
+    setIsSettingsPanelShown
+  );
+  const toggleShowGriftCounter = makeToggleFunction(
+    isGriftCounterExpanded,
+    setIsGriftCounterExpanded,
+    LOCALSTORAGE_KEYS.griftCounterExpanded
+  );
+  const toggleIsGriftCounterCountingUp = makeToggleFunction(
+    isGriftCounterCountingUp,
+    setIsGriftCounterCountingUp,
+    LOCALSTORAGE_KEYS.griftCounterCountUp
+  );
+  const toggleFlamesAnimation = makeToggleFunction(
+    isAnimationPaused,
+    setIsAnimationPaused,
+    LOCALSTORAGE_KEYS.flamesAnimationPaused
+  );
 
   if (!isBrowserRendering) {
     return null;
   }
 
+  const renderSettingsButton = () => (
+    <button
+      onClick={toggleShowSettingsPanel}
+      title={`${isSettingsPanelShown ? "Hide" : "Show"} settings panel`}
+      className="fixed-at-bottom-button"
+    >
+      <i className="fas fa-gear" aria-hidden={true}>
+        <span className="sr-only">
+          {`${isSettingsPanelShown ? "Hide" : "Show"} settings panel`}
+        </span>
+      </i>
+    </button>
+  );
+
   return (
     <div className="fix-at-bottom">
       {!headerInView && <ScrollToTop scrollToTop={scrollToTop} />}
-      {shouldRenderGriftCounter && (
-        <GriftCounter total={currentRunningScamTotal} />
+      {renderSettingsButton()}
+      {isSettingsPanelShown && (
+        <SettingsPanel
+          setIsSettingsPanelShown={setIsSettingsPanelShown}
+          isAnimationPaused={isAnimationPaused}
+          toggleFlamesAnimation={toggleFlamesAnimation}
+          isGriftCounterExpanded={isGriftCounterExpanded}
+          toggleShowGriftCounter={toggleShowGriftCounter}
+          isGriftCounterCountingUp={isGriftCounterCountingUp}
+          toggleIsGriftCounterCountingUp={toggleIsGriftCounterCountingUp}
+        />
+      )}
+      {shouldRenderGriftCounter && isGriftCounterExpanded && (
+        <GriftCounter
+          runningGriftTotal={runningGriftTotal}
+          griftTotal={griftTotal}
+          isGriftCounterCountingUp={isGriftCounterCountingUp}
+          isAnimationPaused={isAnimationPaused}
+        />
       )}
     </div>
   );
@@ -30,5 +128,6 @@ FixedAtBottom.propTypes = {
   headerInView: PropTypes.bool.isRequired,
   shouldRenderGriftCounter: PropTypes.bool.isRequired,
   scrollToTop: PropTypes.func.isRequired,
-  currentRunningScamTotal: PropTypes.number.isRequired,
+  runningGriftTotal: PropTypes.number.isRequired,
+  griftTotal: PropTypes.number.isRequired,
 };

--- a/src/components/timeline/GriftCounter.js
+++ b/src/components/timeline/GriftCounter.js
@@ -1,102 +1,40 @@
-import { useState, useMemo } from "react";
 import PropTypes from "prop-types";
 import clsx from "clsx";
-import {
-  getLocalStorage,
-  LOCALSTORAGE_KEYS,
-  setLocalStorage,
-} from "../../js/localStorage";
 
-export default function GriftCounter({ total }) {
-  const prefersReducedMotion = useMemo(() => {
-    const result = window.matchMedia("(prefers-reduced-motion: reduce)");
-    return result && result.matches;
-  }, []);
+const getDisplayNumber = (num) => {
+  if (num < 1e6) {
+    return num.toLocaleString();
+  } else if (num < 1e9) {
+    return `${(num / 1e6).toFixed(2)} million`;
+  } else if (num < 1e12) {
+    return `${(num / 1e9).toFixed(3)} billion`;
+  } else {
+    return `${(num / 1e12).toFixed(3)} trillion`;
+  }
+};
 
-  const [isExpanded, setIsExpanded] = useState(
-    getLocalStorage(LOCALSTORAGE_KEYS.griftCounterExpanded, true)
-  );
-  const [isPaused, setIsPaused] = useState(
-    getLocalStorage(LOCALSTORAGE_KEYS.flamesAnimationPaused, null) ||
-      prefersReducedMotion ||
-      null
-  );
-
-  const toggleFlamesAnimation = () => {
-    if (isPaused) {
-      setLocalStorage(LOCALSTORAGE_KEYS.flamesAnimationPaused, false);
-      setIsPaused(false);
-    } else {
-      setLocalStorage(LOCALSTORAGE_KEYS.flamesAnimationPaused, true);
-      setIsPaused(true);
-    }
-  };
-
-  const showOrHideCounter = () => {
-    if (isExpanded) {
-      setLocalStorage(LOCALSTORAGE_KEYS.griftCounterExpanded, false);
-      setIsExpanded(false);
-    } else {
-      setLocalStorage(LOCALSTORAGE_KEYS.griftCounterExpanded, true);
-      setIsExpanded(true);
-    }
-  };
-
-  const getDisplayNumber = () => {
-    if (total < 1e6) {
-      return total.toLocaleString();
-    } else if (total < 1e9) {
-      return `${(total / 1e6).toFixed(2)} million`;
-    } else if (total < 1e12) {
-      return `${(total / 1e9).toFixed(3)} billion`;
-    } else {
-      return `${(total / 1e12).toFixed(3)} trillion`;
-    }
-  };
-
-  const renderButtons = () => (
-    <>
-      <button
-        onClick={showOrHideCounter}
-        title={`${isExpanded ? "Collapse" : "Expand"} counter`}
-      >
-        <i
-          className={`fas fa-${isExpanded ? "eye-slash" : "fire"}`}
-          aria-hidden={true}
-        >
-          <span className="sr-only">
-            ${isExpanded ? "Collapse" : "Expand"} counter
-          </span>
-        </i>
-      </button>
-      <button
-        onClick={toggleFlamesAnimation}
-        className="pause-button"
-        title={isPaused ? "Animate flames" : "Stop flames animation"}
-      >
-        <i
-          className={`fas fa-${isPaused ? "play" : "fire-extinguisher"}`}
-          aria-hidden={true}
-        >
-          <span className="sr-only">
-            ${isPaused ? "Animate flames" : "Stop flames animation"}
-          </span>
-        </i>
-      </button>
-    </>
-  );
+export default function GriftCounter({
+  runningGriftTotal,
+  griftTotal,
+  isAnimationPaused,
+  isGriftCounterCountingUp,
+}) {
+  const numberToShow = isGriftCounterCountingUp
+    ? runningGriftTotal
+    : griftTotal - runningGriftTotal;
 
   return (
     <div
-      className={clsx("grift-counter", !isExpanded && "collapsed", {
-        "no-animate": isPaused === true,
-        animate: isPaused === false,
+      className={clsx("grift-counter", {
+        "no-animate": isAnimationPaused,
+        animate: !isAnimationPaused,
       })}
     >
       <div>
-        {renderButtons()}
         <a href="/about#grift-question" target="_blank">
-          <span title="W3IGG Grift Counter™">${getDisplayNumber()}</span>
+          <span title="W3IGG Grift Counter™">
+            ${getDisplayNumber(numberToShow)}
+          </span>
         </a>
       </div>
     </div>
@@ -104,5 +42,8 @@ export default function GriftCounter({ total }) {
 }
 
 GriftCounter.propTypes = {
-  total: PropTypes.number.isRequired,
+  runningGriftTotal: PropTypes.number.isRequired,
+  griftTotal: PropTypes.number.isRequired,
+  isAnimationPaused: PropTypes.bool,
+  isGriftCounterCountingUp: PropTypes.bool.isRequired,
 };

--- a/src/components/timeline/ScrollToTop.js
+++ b/src/components/timeline/ScrollToTop.js
@@ -2,7 +2,7 @@ import PropTypes from "prop-types";
 
 export default function ScrollToTop({ scrollToTop }) {
   return (
-    <button className="scroll-to-top" onClick={scrollToTop}>
+    <button className="fixed-at-bottom-button" onClick={scrollToTop}>
       <i className="fas fa-arrow-up" aria-hidden={true}></i>
       <span className="sr-only">Scroll to top</span>
     </button>

--- a/src/components/timeline/SettingsPanel.js
+++ b/src/components/timeline/SettingsPanel.js
@@ -1,0 +1,83 @@
+import PropTypes from "prop-types";
+
+export default function SettingsPanel({
+  setIsSettingsPanelShown,
+  isAnimationPaused,
+  toggleFlamesAnimation,
+  isGriftCounterExpanded,
+  toggleShowGriftCounter,
+  isGriftCounterCountingUp,
+  toggleIsGriftCounterCountingUp,
+}) {
+  return (
+    <div className="settings-panel">
+      <div className="header-and-close">
+        <h3>Settings</h3>
+        <button onClick={() => setIsSettingsPanelShown(false)}>
+          <i className="fas fa-xmark" aria-hidden={true}></i>
+          <span className="sr-only">Close settings panel</span>
+        </button>
+      </div>
+      <div className="input-group">
+        <input
+          type="checkbox"
+          id="show-grift-counter"
+          name="show-grift-counter"
+          checked={isGriftCounterExpanded}
+          onChange={toggleShowGriftCounter}
+        />
+        <label htmlFor="show-grift-counter">Show grift counter</label>
+      </div>
+      <div className="input-group">
+        <input
+          type="checkbox"
+          id="animate-flames"
+          name="animate-flames"
+          checked={!isAnimationPaused}
+          onChange={toggleFlamesAnimation}
+        />
+        <label htmlFor="animate-flames">Animate flames</label>
+      </div>
+      <div className="radio-group">
+        <h4>Grift counter direction</h4>
+        <div className="input-group">
+          <input
+            type="radio"
+            id="count-up"
+            name="grift-direction"
+            value="count-up"
+            checked={isGriftCounterCountingUp}
+            onChange={toggleIsGriftCounterCountingUp}
+          />
+          <label htmlFor="count-up">Start at $0 and add as you scroll</label>
+        </div>
+        <div className="input-group">
+          <input
+            type="radio"
+            id="count-down"
+            name="grift-direction"
+            value="count-down"
+            checked={!isGriftCounterCountingUp}
+            onChange={toggleIsGriftCounterCountingUp}
+          />
+          <label htmlFor="count-down">
+            Start at total amount scammed and subtract as you scroll
+          </label>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+SettingsPanel.propTypes = {
+  setIsSettingsPanelShown: PropTypes.func.isRequired,
+
+  isAnimationPaused: PropTypes.bool, // Can be null
+  toggleFlamesAnimation: PropTypes.func.isRequired,
+
+  isGriftCounterExpanded: PropTypes.bool.isRequired,
+  toggleShowGriftCounter: PropTypes.func.isRequired,
+
+  isGriftCounterCountingUp: PropTypes.bool.isRequired,
+  toggleIsGriftCounterCountingUp: PropTypes.func.isRequired,
+};

--- a/src/components/timeline/Timeline.js
+++ b/src/components/timeline/Timeline.js
@@ -13,10 +13,9 @@ import CustomEntryHead from "../CustomEntryHead";
 import Header from "./Header";
 import Filters from "./Filters";
 import Entry from "./Entry";
+import FixedAtBottom from "./FixedAtBottom";
 import Loader from "../Loader";
 import Error from "../Error";
-import ScrollToTop from "./ScrollToTop";
-import GriftCounter from "./GriftCounter";
 
 export default function Timeline({
   queryResult,
@@ -205,14 +204,12 @@ export default function Timeline({
           {renderBody()}
         </div>
       </div>
-      {isBrowserRendering && (
-        <div className="fix-at-bottom">
-          {!headerInView && <ScrollToTop scrollToTop={scrollToTop} />}
-          {(!startAtId || !hasPreviousEntries) && (
-            <GriftCounter total={currentRunningScamTotal} />
-          )}
-        </div>
-      )}
+      <FixedAtBottom
+        headerInView={headerInView}
+        shouldRenderGriftCounter={!startAtId || !hasPreviousEntries}
+        scrollToTop={scrollToTop}
+        currentRunningScamTotal={currentRunningScamTotal}
+      />
     </>
   );
 }

--- a/src/components/timeline/Timeline.js
+++ b/src/components/timeline/Timeline.js
@@ -21,6 +21,7 @@ export default function Timeline({
   queryResult,
   filters,
   glossary,
+  griftTotal,
   selectedEntryFromSearch,
   startAtId,
   setFilters,
@@ -208,7 +209,8 @@ export default function Timeline({
         headerInView={headerInView}
         shouldRenderGriftCounter={!startAtId || !hasPreviousEntries}
         scrollToTop={scrollToTop}
-        currentRunningScamTotal={currentRunningScamTotal}
+        runningGriftTotal={currentRunningScamTotal}
+        griftTotal={griftTotal}
       />
     </>
   );
@@ -226,6 +228,7 @@ Timeline.propTypes = {
   }),
   filters: FiltersPropType.isRequired,
   glossary: PropTypes.object.isRequired,
+  griftTotal: PropTypes.number.isRequired,
   selectedEntryFromSearch: PropTypes.string,
   startAtId: PropTypes.string,
   setFilters: PropTypes.func.isRequired,

--- a/src/db/metadata.js
+++ b/src/db/metadata.js
@@ -1,0 +1,11 @@
+import { collection, getDoc, doc } from "firebase/firestore/lite";
+import { db } from "./db";
+
+export const getMetadata = async () => {
+  const metadataCollection = collection(db, "metadata");
+
+  const metadataDocSnapshot = await getDoc(doc(metadataCollection, "metadata"));
+  const metadata = metadataDocSnapshot.data();
+
+  return metadata;
+};

--- a/src/js/localStorage.js
+++ b/src/js/localStorage.js
@@ -1,6 +1,7 @@
 export const LOCALSTORAGE_KEYS = {
   flamesAnimationPaused: "flames-animation-paused",
   griftCounterExpanded: "grift-counter-expanded",
+  griftCounterCountUp: "grift-counter-count-up",
 };
 
 export const getLocalStorage = (key, returnValueIfNotSet = null) => {

--- a/src/styles/_fixed-at-bottom.sass
+++ b/src/styles/_fixed-at-bottom.sass
@@ -8,14 +8,15 @@
   display: flex
   align-items: flex-end
 
-.grift-counter, .scroll-to-top
+.grift-counter, .fixed-at-bottom-button
   box-shadow: 0px 1px 1px rgba(0, 0, 0, 0.4)
 
-.scroll-to-top
+.fixed-at-bottom-button
   background-color: $accent
-  color: transparentize($title-color, 0.25)
+  color: $title-color
   padding: 5px 10px
   height: 29px
+  margin-right: 5px
 
 .grift-counter
   box-sizing: content-box
@@ -25,7 +26,6 @@
   border-image-source: url(https://storage.googleapis.com/web3-334501.appspot.com/flames.gif)
   border-image-slice: 16 0
   border-image-repeat: repeat
-  margin-left: 10px
 
   &.no-animate
     border-image-source: url(https://storage.googleapis.com/web3-334501.appspot.com/flames.png)
@@ -67,8 +67,43 @@
       padding-right: 10px
       border-right: 1px solid transparentize($title-color, 0.5)
 
+.settings-panel
+  position: fixed
+  bottom: 45px
+  right: min(5%, 30px)
+  z-index: 5
+  background-color: $card-background
+  box-shadow: 0px 1px 1px rgba(0, 0, 0, 0.4)
+  width: 90%
+  max-width: 300px
+  padding: 10px
+
+  .header-and-close
+    display: flex
+    justify-content: space-between
+    align-items: center
+    margin-bottom: 10px
+
+  h3
+    margin: 0
+
+  input
+    margin-right: 5px
+
+  .input-group
+    display: flex
+    align-items: center
+    margin-bottom: 5px
+
+  .radio-group
+    h4
+      margin: 10px 0 5px 0
+
+    .input-group
+      align-items: baseline
+
 @media (prefers-color-scheme: dark)
-  .grift-counter, .scroll-to-top
+  .grift-counter, .fixed-at-bottom-button
     filter: brightness(80%)
 
 @media (prefers-reduced-motion: reduce)

--- a/src/styles/main.sass
+++ b/src/styles/main.sass
@@ -325,7 +325,7 @@ div.content-wrapper
 
   .contents
     width: 90%
-    max-width: 1600px
+    max-width: 16k00px
     padding: 10px 0
     margin: 0 auto
 


### PR DESCRIPTION
Now users can optionally have the grift counter start at the total amount scammed and count down as they scroll, rather than starting at $0.

I've also moved the mess of buttons to the settings panel, since it was getting to be a lot.
<img width="355" alt="Screen Shot 2022-02-16 at 12 35 46 AM" src="https://user-images.githubusercontent.com/2487900/154202872-ca07256b-73ff-46c8-8900-64948fba5d10.png">
