### PR TITLE
Add options to force dark mode, and to use sans-serif font

### DIFF
--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -3,13 +3,12 @@ import clsx from "clsx";
 import { useAppState } from "../context/AppContext";
 
 export default function Layout({ children }) {
-  const { colorModeOverride, useSansSerif } = useAppState();
+  const { useDarkMode, useSansSerif } = useAppState();
 
   return (
     <main
       className={clsx([
-        colorModeOverride ? `use-${colorModeOverride}` : null,
-        { "use-sans-serif": useSansSerif },
+        { "use-sans-serif": useSansSerif, "use-dark": useDarkMode },
       ])}
     >
       {children}

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -1,0 +1,22 @@
+import PropTypes from "prop-types";
+import clsx from "clsx";
+import { useAppState } from "../context/AppContext";
+
+export default function Layout({ children }) {
+  const { colorModeOverride, useSansSerif } = useAppState();
+
+  return (
+    <main
+      className={clsx([
+        colorModeOverride ? `use-${colorModeOverride}` : null,
+        { "use-sans-serif": useSansSerif },
+      ])}
+    >
+      {children}
+    </main>
+  );
+}
+
+Layout.propTypes = {
+  children: PropTypes.node.isRequired,
+};

--- a/src/components/timeline/FixedAtBottom.js
+++ b/src/components/timeline/FixedAtBottom.js
@@ -1,4 +1,5 @@
 import PropTypes from "prop-types";
+
 import { useState, useMemo, useCallback } from "react";
 import useIsBrowserRendering from "../../hooks/useIsBrowserRendering";
 
@@ -126,6 +127,7 @@ export default function FixedAtBottom({
       )}
       {shouldRenderGriftCounter && isGriftCounterExpanded && (
         <GriftCounter
+          onClick={toggleShowSettingsPanel}
           runningGriftTotal={runningGriftTotal}
           griftTotal={griftTotal}
           isGriftCounterCountingUp={isGriftCounterCountingUp}

--- a/src/components/timeline/GriftCounter.js
+++ b/src/components/timeline/GriftCounter.js
@@ -18,6 +18,7 @@ export default function GriftCounter({
   griftTotal,
   isAnimationPaused,
   isGriftCounterCountingUp,
+  onClick,
 }) {
   const numberToShow = isGriftCounterCountingUp
     ? runningGriftTotal
@@ -31,11 +32,11 @@ export default function GriftCounter({
       })}
     >
       <div>
-        <a href="/about#grift-question" target="_blank">
+        <button onClick={onClick}>
           <span title="W3IGG Grift Counter™">
             ${getDisplayNumber(numberToShow)}
           </span>
-        </a>
+        </button>
       </div>
     </div>
   );
@@ -46,4 +47,5 @@ GriftCounter.propTypes = {
   griftTotal: PropTypes.number.isRequired,
   isAnimationPaused: PropTypes.bool,
   isGriftCounterCountingUp: PropTypes.bool.isRequired,
+  onClick: PropTypes.func.isRequired,
 };

--- a/src/components/timeline/SettingsCheckbox.js
+++ b/src/components/timeline/SettingsCheckbox.js
@@ -1,0 +1,28 @@
+import PropTypes from "prop-types";
+
+export default function SettingsCheckbox({
+  checked,
+  toggleCheckbox,
+  id,
+  children,
+}) {
+  return (
+    <div className="input-group">
+      <input
+        type="checkbox"
+        id={id}
+        name={id}
+        checked={checked}
+        onChange={toggleCheckbox}
+      />
+      <label htmlFor={id}>{children}</label>
+    </div>
+  );
+}
+
+SettingsCheckbox.propTypes = {
+  checked: PropTypes.bool.isRequired,
+  toggleCheckbox: PropTypes.func.isRequired,
+  id: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
+};

--- a/src/components/timeline/SettingsPanel.js
+++ b/src/components/timeline/SettingsPanel.js
@@ -1,4 +1,8 @@
 import PropTypes from "prop-types";
+import { useAppState } from "../../context/AppContext";
+import { COLOR_MODE_MAP, COLOR_MODES } from "../../constants/colorModes";
+import SettingsCheckbox from "./SettingsCheckbox";
+import Select from "react-select";
 
 export default function SettingsPanel({
   setIsSettingsPanelShown,
@@ -9,61 +13,89 @@ export default function SettingsPanel({
   isGriftCounterCountingUp,
   toggleIsGriftCounterCountingUp,
 }) {
+  const {
+    colorModeOverride,
+    useSansSerif,
+    toggleUseSansSerif,
+    setColorModeOverride,
+  } = useAppState();
+
   return (
     <div className="settings-panel">
       <div className="header-and-close">
-        <h3>Settings</h3>
+        <h2>Settings</h2>
         <button onClick={() => setIsSettingsPanelShown(false)}>
           <i className="fas fa-xmark" aria-hidden={true}></i>
           <span className="sr-only">Close settings panel</span>
         </button>
       </div>
-      <div className="input-group">
-        <input
-          type="checkbox"
+      <h3>Appearance</h3>
+      <div className="settings-section">
+        <SettingsCheckbox
+          id="use-sans-serif-font"
+          checked={useSansSerif}
+          toggleCheckbox={toggleUseSansSerif}
+        >
+          Use sans-serif font
+        </SettingsCheckbox>
+        <label htmlFor="color-mode-override">Mode</label>
+        <Select
+          instanceId="color-mode-override"
+          options={COLOR_MODES}
+          onChange={({ value }) => setColorModeOverride(value)}
+          value={
+            colorModeOverride
+              ? COLOR_MODE_MAP[colorModeOverride]
+              : COLOR_MODE_MAP.default
+          }
+        />
+      </div>
+      <h3>Grift counter</h3>
+      <div className="settings-section">
+        <SettingsCheckbox
           id="show-grift-counter"
-          name="show-grift-counter"
           checked={isGriftCounterExpanded}
-          onChange={toggleShowGriftCounter}
-        />
-        <label htmlFor="show-grift-counter">Show grift counter</label>
-      </div>
-      <div className="input-group">
-        <input
-          type="checkbox"
+          toggleCheckbox={toggleShowGriftCounter}
+        >
+          Show grift counter
+        </SettingsCheckbox>
+        <SettingsCheckbox
           id="animate-flames"
-          name="animate-flames"
           checked={!isAnimationPaused}
-          onChange={toggleFlamesAnimation}
-        />
-        <label htmlFor="animate-flames">Animate flames</label>
-      </div>
-      <div className="radio-group">
-        <h4>Grift counter direction</h4>
-        <div className="input-group">
-          <input
-            type="radio"
-            id="count-up"
-            name="grift-direction"
-            value="count-up"
-            checked={isGriftCounterCountingUp}
-            onChange={toggleIsGriftCounterCountingUp}
-          />
-          <label htmlFor="count-up">Start at $0 and add as you scroll</label>
+          toggleCheckbox={toggleFlamesAnimation}
+        >
+          Animate flames
+        </SettingsCheckbox>
+        <div className="radio-group">
+          <h4>Grift counter direction</h4>
+          <div className="input-group">
+            <input
+              type="radio"
+              id="count-up"
+              name="grift-direction"
+              value="count-up"
+              checked={isGriftCounterCountingUp}
+              onChange={toggleIsGriftCounterCountingUp}
+            />
+            <label htmlFor="count-up">Start at $0 and add as you scroll</label>
+          </div>
+          <div className="input-group">
+            <input
+              type="radio"
+              id="count-down"
+              name="grift-direction"
+              value="count-down"
+              checked={!isGriftCounterCountingUp}
+              onChange={toggleIsGriftCounterCountingUp}
+            />
+            <label htmlFor="count-down">
+              Start at total amount scammed and subtract as you scroll
+            </label>
+          </div>
         </div>
-        <div className="input-group">
-          <input
-            type="radio"
-            id="count-down"
-            name="grift-direction"
-            value="count-down"
-            checked={!isGriftCounterCountingUp}
-            onChange={toggleIsGriftCounterCountingUp}
-          />
-          <label htmlFor="count-down">
-            Start at total amount scammed and subtract as you scroll
-          </label>
-        </div>
+        <a className="help-text" href="/about#grift-question" target="_blank">
+          What's the grift counter?
+        </a>
       </div>
     </div>
   );

--- a/src/components/timeline/SettingsPanel.js
+++ b/src/components/timeline/SettingsPanel.js
@@ -1,8 +1,6 @@
 import PropTypes from "prop-types";
 import { useAppState } from "../../context/AppContext";
-import { COLOR_MODE_MAP, COLOR_MODES } from "../../constants/colorModes";
 import SettingsCheckbox from "./SettingsCheckbox";
-import Select from "react-select";
 
 export default function SettingsPanel({
   setIsSettingsPanelShown,
@@ -13,12 +11,8 @@ export default function SettingsPanel({
   isGriftCounterCountingUp,
   toggleIsGriftCounterCountingUp,
 }) {
-  const {
-    colorModeOverride,
-    useSansSerif,
-    toggleUseSansSerif,
-    setColorModeOverride,
-  } = useAppState();
+  const { useDarkMode, useSansSerif, toggleUseSansSerif, toggleDarkMode } =
+    useAppState();
 
   return (
     <div className="settings-panel">
@@ -38,17 +32,13 @@ export default function SettingsPanel({
         >
           Use sans-serif font
         </SettingsCheckbox>
-        <label htmlFor="color-mode-override">Mode</label>
-        <Select
-          instanceId="color-mode-override"
-          options={COLOR_MODES}
-          onChange={({ value }) => setColorModeOverride(value)}
-          value={
-            colorModeOverride
-              ? COLOR_MODE_MAP[colorModeOverride]
-              : COLOR_MODE_MAP.default
-          }
-        />
+        <SettingsCheckbox
+          id="use-dark-mode"
+          checked={useDarkMode}
+          toggleCheckbox={toggleDarkMode}
+        >
+          Force dark mode
+        </SettingsCheckbox>
       </div>
       <h3>Grift counter</h3>
       <div className="settings-section">

--- a/src/constants/colorModes.js
+++ b/src/constants/colorModes.js
@@ -1,0 +1,17 @@
+export const COLOR_MODE_MAP = {
+  default: {
+    value: null,
+    label: "Browser default",
+  },
+  dark: {
+    value: "dark",
+    label: "Dark mode",
+  },
+  light: { value: "light", label: "Light mode" },
+};
+
+export const COLOR_MODES = [
+  COLOR_MODE_MAP.default,
+  COLOR_MODE_MAP.light,
+  COLOR_MODE_MAP.dark,
+];

--- a/src/context/AppContext.js
+++ b/src/context/AppContext.js
@@ -1,0 +1,54 @@
+/* eslint-disable no-unused-vars */
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
+import PropTypes from "prop-types";
+import {
+  getLocalStorage,
+  LOCALSTORAGE_KEYS,
+  setLocalStorage,
+} from "../js/localStorage";
+
+export const AppContext = createContext();
+
+export function AppProvider({ children }) {
+  const [colorModeOverride, setColorModeOverrideState] = useState(null);
+  const [useSansSerif, setUseSansSerif] = useState(null);
+
+  const toggleUseSansSerif = useCallback(() => {
+    setUseSansSerif(!useSansSerif);
+    setLocalStorage(LOCALSTORAGE_KEYS.useSansSerif, !useSansSerif);
+  }, [useSansSerif]);
+
+  const setColorModeOverride = useCallback((mode) => {
+    setColorModeOverrideState(mode);
+    setLocalStorage(LOCALSTORAGE_KEYS.colorModeOverride, mode);
+  }, []);
+
+  useEffect(() => {
+    // Localstorage can't be accessed during SSR
+    setUseSansSerif(getLocalStorage(LOCALSTORAGE_KEYS.useSansSerif));
+    setColorModeOverride(getLocalStorage(LOCALSTORAGE_KEYS.colorModeOverride));
+  }, [setUseSansSerif, setColorModeOverride]);
+
+  const state = {
+    colorModeOverride,
+    useSansSerif,
+    toggleUseSansSerif,
+    setColorModeOverride,
+  };
+
+  return <AppContext.Provider value={state}>{children}</AppContext.Provider>;
+}
+
+AppProvider.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export function useAppState() {
+  return useContext(AppContext);
+}

--- a/src/context/AppContext.js
+++ b/src/context/AppContext.js
@@ -16,30 +16,30 @@ import {
 export const AppContext = createContext();
 
 export function AppProvider({ children }) {
-  const [colorModeOverride, setColorModeOverrideState] = useState(null);
+  const [useDarkMode, setUseDarkMode] = useState(null);
   const [useSansSerif, setUseSansSerif] = useState(null);
 
   const toggleUseSansSerif = useCallback(() => {
-    setUseSansSerif(!useSansSerif);
     setLocalStorage(LOCALSTORAGE_KEYS.useSansSerif, !useSansSerif);
+    setUseSansSerif(!useSansSerif);
   }, [useSansSerif]);
 
-  const setColorModeOverride = useCallback((mode) => {
-    setColorModeOverrideState(mode);
-    setLocalStorage(LOCALSTORAGE_KEYS.colorModeOverride, mode);
-  }, []);
+  const toggleDarkMode = useCallback(() => {
+    setLocalStorage(LOCALSTORAGE_KEYS.useDarkMode, !useDarkMode);
+    setUseDarkMode(!useDarkMode);
+  }, [useDarkMode]);
 
   useEffect(() => {
     // Localstorage can't be accessed during SSR
     setUseSansSerif(getLocalStorage(LOCALSTORAGE_KEYS.useSansSerif));
-    setColorModeOverride(getLocalStorage(LOCALSTORAGE_KEYS.colorModeOverride));
-  }, [setUseSansSerif, setColorModeOverride]);
+    setUseDarkMode(getLocalStorage(LOCALSTORAGE_KEYS.useDarkMode));
+  }, [setUseSansSerif, setUseDarkMode]);
 
   const state = {
-    colorModeOverride,
+    useDarkMode,
     useSansSerif,
     toggleUseSansSerif,
-    setColorModeOverride,
+    toggleDarkMode,
   };
 
   return <AppContext.Provider value={state}>{children}</AppContext.Provider>;

--- a/src/js/localStorage.js
+++ b/src/js/localStorage.js
@@ -1,4 +1,9 @@
 export const LOCALSTORAGE_KEYS = {
+  // General appearance
+  colorModeOverride: "color-mode-override",
+  useSansSerif: "use-sans-serif",
+
+  // Grift counter
   flamesAnimationPaused: "flames-animation-paused",
   griftCounterExpanded: "grift-counter-expanded",
   griftCounterCountUp: "grift-counter-count-up",

--- a/src/js/localStorage.js
+++ b/src/js/localStorage.js
@@ -1,6 +1,6 @@
 export const LOCALSTORAGE_KEYS = {
   // General appearance
-  colorModeOverride: "color-mode-override",
+  useDarkMode: "use-dark-mode",
   useSansSerif: "use-sans-serif",
 
   // Grift counter

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -3,6 +3,8 @@ import PropTypes from "prop-types";
 import ReactGA from "react-ga";
 import Head from "next/head";
 import { QueryClient, QueryClientProvider } from "react-query";
+import Layout from "../components/Layout";
+import { AppProvider } from "../context/AppContext";
 
 if (typeof window !== "undefined") {
   ReactGA.initialize("UA-215114522-1");
@@ -85,7 +87,11 @@ function CustomApp({ Component, pageProps }) {
         />
       </Head>
       <QueryClientProvider client={queryClient}>
-        <Component {...pageProps} />
+        <AppProvider>
+          <Layout>
+            <Component {...pageProps} />
+          </Layout>
+        </AppProvider>
       </QueryClientProvider>
     </>
   );

--- a/src/pages/_document.js
+++ b/src/pages/_document.js
@@ -1,41 +1,39 @@
-import Document, { Html, Head, Main, NextScript } from "next/document";
+import { Html, Head, Main, NextScript } from "next/document";
 
-class CustomDocument extends Document {
-  render() {
-    return (
-      <Html>
-        <Head>
-          <link rel="shortcut icon" href="/favicon.ico" />
-          <link rel="apple-touch-icon" href="/logo192.png" />
-          <link
-            rel="icon"
-            type="image/png"
-            sizes="32x32"
-            href="/favicon-32x32.png"
-          />
-          <link
-            rel="icon"
-            type="image/png"
-            sizes="16x16"
-            href="/favicon-16x16.png"
-          />
-          <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5948a4" />
-          <link rel="shortcut icon" href="/favicon.ico" />
-          <link rel="manifest" href="/manifest.json" />
-          <link
-            rel="alternate"
-            type="application/atom+xml"
-            title="Subscribe to this timeline"
-            href="https://web3isgoinggreat.com/feed.xml"
-          />
-        </Head>
-        <body>
-          <Main />
-          <NextScript />
-        </body>
-      </Html>
-    );
-  }
-}
+const Document = () => {
+  return (
+    <Html>
+      <Head>
+        <link rel="shortcut icon" href="/favicon.ico" />
+        <link rel="apple-touch-icon" href="/logo192.png" />
+        <link
+          rel="icon"
+          type="image/png"
+          sizes="32x32"
+          href="/favicon-32x32.png"
+        />
+        <link
+          rel="icon"
+          type="image/png"
+          sizes="16x16"
+          href="/favicon-16x16.png"
+        />
+        <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5948a4" />
+        <link rel="shortcut icon" href="/favicon.ico" />
+        <link rel="manifest" href="/manifest.json" />
+        <link
+          rel="alternate"
+          type="application/atom+xml"
+          title="Subscribe to this timeline"
+          href="https://web3isgoinggreat.com/feed.xml"
+        />
+      </Head>
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  );
+};
 
-export default CustomDocument;
+export default Document;

--- a/src/styles/_filters.sass
+++ b/src/styles/_filters.sass
@@ -195,7 +195,7 @@
     justify-content: center
 
 // Dark mode
-@media (prefers-color-scheme: dark)
+@mixin filtersDarkMode()
   .timeline-filter-wrapper
     background-color: $dark-filterbar-background
     color: $dark-filter-text
@@ -212,6 +212,7 @@
       border-color: $dark-timeline-line-color
 
   .filter-select
+
     >div
       background-color: $dark-lightbox-background
       border-color: $dark-timeline-line-color
@@ -220,7 +221,7 @@
       border-color: $dark-card-background !important
       box-shadow: $dark-card-background !important
 
-    div[class*="-placeholder"]
+    div[class*="-placeholder"],  div[class*="-singleValue"]
       color: $dark-filter-text
 
     div[class*="-indicatorContainer"]:hover

--- a/src/styles/_fixed-at-bottom.sass
+++ b/src/styles/_fixed-at-bottom.sass
@@ -86,12 +86,18 @@
       align-items: baseline
 
   .settings-section
-    margin: 10px 0 10px 10px
+    margin: 10px 0 10px 15px
 
 .use-sans-serif .grift-counter > div
   font-family: $sans-serif-body-font
 
-@media (prefers-color-scheme: dark)
+@media (prefers-reduced-motion: reduce)
+  .grift-counter
+    // People with prefers-reduced-motion set can still opt in to the animation, in which case
+    // .animate will also be set, and this will be overriden by the more specific selector above
+    border-image-source: url(https://storage.googleapis.com/web3-334501.appspot.com/flames.png)
+
+@mixin fixedDarkMode()
   .grift-counter, .fixed-at-bottom-button
     filter: brightness(80%)
 
@@ -101,9 +107,3 @@
 
     button
       color: $dark-main-color
-
-@media (prefers-reduced-motion: reduce)
-  .grift-counter
-    // People with prefers-reduced-motion set can still opt in to the animation, in which case
-    // .animate will also be set, and this will be overriden by the more specific selector above
-    border-image-source: url(https://storage.googleapis.com/web3-334501.appspot.com/flames.png)

--- a/src/styles/_fixed-at-bottom.sass
+++ b/src/styles/_fixed-at-bottom.sass
@@ -24,6 +24,7 @@
 .grift-counter
   box-sizing: content-box
   border-top: 16px solid #0000
+  height: 28px
   border-bottom: 0
   border-right: 0
   border-image-source: url(https://storage.googleapis.com/web3-334501.appspot.com/flames.gif)
@@ -42,33 +43,8 @@
     color: $title-color
     padding: 5px 10px
 
-  a
-    color: $title-color
-
-    &:hover
-      text-decoration: none
-
-  &.collapsed
-    border: none
-
-    span, .pause-button
-      display: none
-
-  span
-    margin-left: 10px
-    vertical-align: bottom
-
   button
-    cursor: pointer
-    background-color: transparent
-    color: transparentize($title-color, 0.25)
-    border: 0
-    padding: 0
-
-    &.pause-button
-      margin-left: 5px
-      padding-right: 10px
-      border-right: 1px solid transparentize($title-color, 0.5)
+    color: $title-color
 
 .settings-panel
   position: fixed
@@ -91,7 +67,7 @@
     align-items: center
     margin-bottom: 10px
 
-  h3
+  h2, h3, h4, h5
     margin: 0
 
   input
@@ -109,10 +85,11 @@
     .input-group
       align-items: baseline
 
-@media only screen and (max-width: #{$md-breakpoint}px)
-  .fixed-at-bottom-button
-    height: 26px
-    width: 26px
+  .settings-section
+    margin: 10px 0 10px 10px
+
+.use-sans-serif .grift-counter > div
+  font-family: $sans-serif-body-font
 
 @media (prefers-color-scheme: dark)
   .grift-counter, .fixed-at-bottom-button

--- a/src/styles/_popovers.sass
+++ b/src/styles/_popovers.sass
@@ -98,7 +98,7 @@
       border-right-width: 0
       border-top-width: 0
 
-@media (prefers-color-scheme: dark)
+@mixin popoversDarkMode()
   .definition-popover,
   .lightbox-container
     background-color: $dark-lightbox-background

--- a/src/styles/_tokens.sass
+++ b/src/styles/_tokens.sass
@@ -1,5 +1,6 @@
 $display-font: 'Press Start 2P'
 $body-font: 'Source Code Pro'
+$sans-serif-body-font: 'Atkinson Hyperlegible'
 
 $lg-breakpoint: 1024
 $md-breakpoint: 768

--- a/src/styles/main.sass
+++ b/src/styles/main.sass
@@ -1,6 +1,6 @@
 @import "normalize.css/normalize"
 @import "@fortawesome/fontawesome-free/css/all"
-@import url("https://fonts.googleapis.com/css2?family=Press+Start+2P&family=Source+Code+Pro:ital,wght@0,400;0,900;1,400;1,900&display=swap")
+@import url("https://fonts.googleapis.com/css2?family=Press+Start+2P&family=Source+Code+Pro:ital,wght@0,400;0,900;1,400;1,900&family=Atkinson+Hyperlegible:ital,wght@0,400;0,700;1,400&display=swap")
 @import _admin
 @import _tokens
 @import _filters
@@ -18,7 +18,10 @@ body
   height: 100%
   background-color: $main-background
   color: $main-text-color
-  font-family: $body-font, sans-serif
+  font-family: $body-font, monospace
+
+main.use-sans-serif
+  font-family: $sans-serif-body-font, sans-serif
 
 *
   box-sizing: border-box
@@ -237,7 +240,6 @@ div.content-wrapper
       padding-left: 20px
 
   h2, h2 > button
-    font-family: $body-font, serif
     font-weight: 900
     line-height: 110%
     margin: 5px 0
@@ -361,6 +363,10 @@ img
 .space-between
   display: flex
   justify-content: space-between
+
+.help-text
+  font-size: 90%
+  font-style: italic
 
 .error-wrapper
   display: flex
@@ -651,9 +657,13 @@ img
   width: 80%
   text-align: center
 
+@media (prefers-reduced-motion: reduce)
+  html
+    scroll-behavior: auto
+
 // DARK MODE
-@media (prefers-color-scheme: dark)
-  body
+@mixin mainDarkMode()
+  main
     background-color: $dark-main-background
 
   header.page-header,
@@ -743,6 +753,9 @@ img
     .timeline-entry.odd .timeline-description::after
       border-right-color: $dark-card-background
 
-@media (prefers-reduced-motion: reduce)
-  html
-    scroll-behavior: auto
+.use-dark
+  background-color: $dark-main-background
+  @include mainDarkMode()
+
+@media (prefers-color-scheme: dark)
+  @include mainDarkMode()

--- a/src/styles/main.sass
+++ b/src/styles/main.sass
@@ -756,6 +756,12 @@ img
 .use-dark
   background-color: $dark-main-background
   @include mainDarkMode()
+  @include filtersDarkMode()
+  @include fixedDarkMode()
+  @include popoversDarkMode()
 
 @media (prefers-color-scheme: dark)
   @include mainDarkMode()
+  @include filtersDarkMode()
+  @include fixedDarkMode()
+  @include popoversDarkMode()


### PR DESCRIPTION
This adds two options to the settings panel:
1. Use a sans-serif font rather than the monospace one (closes #156)
2. Display in dark mode even if the browser doesn't have `prefers-color-scheme: dark` set