### PR TITLE
Use dynamically sized images

### DIFF
--- a/functions/ejs/rss.ejs
+++ b/functions/ejs/rss.ejs
@@ -31,7 +31,7 @@
     <content type="xhtml">
       <div xmlns="http://www.w3.org/1999/xhtml">
         <% if (entry.image){%><img
-          src="<%= storageUrlPrefix %>/entryAssets/<%= entry.image.src %>"
+          src="<%= storageUrlPrefix %>/entryImages/resized/<%= entry.image.src.split('.')[0] %>_500x625.webp"
           alt="<%= entry.image.alt %>"
           width="300px"
         /><% } %>

--- a/src/components/CustomEntryHead.js
+++ b/src/components/CustomEntryHead.js
@@ -21,7 +21,9 @@ export default function CustomEntryHead({ entry, collection }) {
 
   const imageSrc =
     entry && entry.image && entry.image.src
-      ? `${STORAGE_URL}/entryAssets/${entry.image.src}`
+      ? `${STORAGE_URL}/entryImages/resized/${entry.image.src.split(
+          "."[0]
+        )}_500x625.webp`
       : null;
 
   useEffect(() => {

--- a/src/components/CustomEntryHead.js
+++ b/src/components/CustomEntryHead.js
@@ -10,6 +10,7 @@ import {
   getImageDimensions,
   getCollectionName,
 } from "../js/utilities";
+import { stripExtension } from "../js/images";
 
 export default function CustomEntryHead({ entry, collection }) {
   const [isWaitingForImageDimensions, setIsWaitingForImageDimensions] =
@@ -21,8 +22,8 @@ export default function CustomEntryHead({ entry, collection }) {
 
   const imageSrc =
     entry && entry.image && entry.image.src
-      ? `${STORAGE_URL}/entryImages/resized/${entry.image.src.split(
-          "."[0]
+      ? `${STORAGE_URL}/entryImages/resized/${stripExtension(
+          entry.image.src
         )}_500x625.webp`
       : null;
 

--- a/src/components/Error.js
+++ b/src/components/Error.js
@@ -24,5 +24,6 @@ Error.propTypes = {
 };
 
 Error.defaultProps = {
-  customMessage: "Site maintenance, hopefully back soon!",
+  customMessage:
+    "Something went wrong. Molly would greatly appreciate it if you made sure she knows.",
 };

--- a/src/components/Error.js
+++ b/src/components/Error.js
@@ -24,6 +24,5 @@ Error.propTypes = {
 };
 
 Error.defaultProps = {
-  customMessage:
-    "Something went wrong. Molly would greatly appreciate it if you made sure she knows.",
+  customMessage: "Site maintenance, hopefully back soon!",
 };

--- a/src/components/timeline/Entry.js
+++ b/src/components/timeline/Entry.js
@@ -5,6 +5,7 @@ import { useRouter } from "next/router";
 
 import PropTypes from "prop-types";
 import { EntryPropType } from "../../js/entry";
+import { getEntryImageProps, getLightboxImageProps } from "../../js/images";
 import { WindowWidthPropType } from "../../hooks/useWindowWidth";
 import clsx from "clsx";
 
@@ -196,16 +197,18 @@ export default function Entry({
     }
   };
 
-  const renderImageElement = (onClick = null) => {
+  const renderImageElement = ({ onClick, isLightbox } = {}) => {
     if (!entry.image) {
       return null;
     }
 
+    const imageProps = isLightbox
+      ? getLightboxImageProps(entry.image.src)
+      : getEntryImageProps(entry.image.src);
     return (
       <img
-        src={`${STORAGE_URL}/entryAssets/${entry.image.src}`}
+        {...imageProps}
         alt={entry.image.alt}
-        layout="fill"
         onClick={onClick}
         className={clsx([{ clickable: !!onClick }, entry.image.class])}
       />
@@ -240,7 +243,7 @@ export default function Entry({
     if (entry.image && (windowWidth !== "sm" || !isLogo)) {
       return (
         <div className="captioned-image image-right">
-          {renderImageElement(() => setShowLightbox(true))}
+          {renderImageElement({ onClick: () => setShowLightbox(true) })}
           {renderImageCaption()}
         </div>
       );
@@ -256,7 +259,9 @@ export default function Entry({
             <i className="fas fa-xmark" aria-hidden={true}></i>
             <span className="sr-only">Close lightbox</span>
           </button>
-          <div className="image-wrapper">{renderImageElement()}</div>
+          <div className="image-wrapper">
+            {renderImageElement({ isLightbox: true })}
+          </div>
           <div className="caption-wrapper">{renderImageCaption()}</div>
         </div>
       );

--- a/src/components/timeline/Header.js
+++ b/src/components/timeline/Header.js
@@ -6,6 +6,7 @@ import { STORAGE_URL } from "../../constants/urls";
 
 import Link from "next/link";
 import ExternalLink from "../ExternalLink";
+import { IMAGE_SIZES } from "../../js/images";
 
 const Header = forwardRef(function Header({ windowWidth, nojs }, ref) {
   const componentRef = useRef();
@@ -45,18 +46,22 @@ const Header = forwardRef(function Header({ windowWidth, nojs }, ref) {
     </>
   );
 
-  const renderImage = () => (
-    <Link href="/">
-      <a className="logo-image-link">
-        {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img
-          className="logo"
-          src={`${STORAGE_URL}/monkey.png`}
-          alt="Illustration: A sad-looking Bored Ape Yacht Club NFT monkey looks at a world engulfed in flames."
-        />
-      </a>
-    </Link>
-  );
+  const renderImage = () => {
+    const imageSize =
+      windowWidth === "xl" ? IMAGE_SIZES["500"] : IMAGE_SIZES["300"];
+    return (
+      <Link href="/">
+        <a className="logo-image-link">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            className="logo"
+            src={`${STORAGE_URL}/monkey_${imageSize.width}x${imageSize.height}.webp`}
+            alt="Illustration: A sad-looking Bored Ape Yacht Club NFT monkey looks at a world engulfed in flames."
+          />
+        </a>
+      </Link>
+    );
+  };
 
   const renderMobileImageAndLinks = () => (
     <div className="mobile-image-and-links">

--- a/src/constants/breakpoints.js
+++ b/src/constants/breakpoints.js
@@ -1,0 +1,3 @@
+export const SM_BREAKPOINT = 414;
+export const MD_BREAKPOINT = 768;
+export const LG_BREAKPOINT = 1024;

--- a/src/db/entries.js
+++ b/src/db/entries.js
@@ -89,7 +89,6 @@ export const getEntries = async ({
     const firstEntryId = await getFirstEntryId(dbCollection);
     resp.hasPrev = firstEntryId !== firstId;
   }
-
   return resp;
 };
 

--- a/src/hooks/useWindowWidth.js
+++ b/src/hooks/useWindowWidth.js
@@ -2,16 +2,18 @@ import { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import { useThrottledCallback } from "use-debounce";
 
-const SMALL_BREAKPOINT = 414;
-const MID_BREAKPOINT = 768;
-const LG_BREAKPOINT = 1024;
+import {
+  SM_BREAKPOINT,
+  MD_BREAKPOINT,
+  LG_BREAKPOINT,
+} from "../constants/breakpoints";
 
 export const WindowWidthPropType = PropTypes.oneOf(["sm", "md", "lg", "xl"]);
 
 const getWindowWidth = (px) => {
-  if (px < SMALL_BREAKPOINT) {
+  if (px < SM_BREAKPOINT) {
     return "sm";
-  } else if (px < MID_BREAKPOINT) {
+  } else if (px < MD_BREAKPOINT) {
     return "md";
   } else if (px < LG_BREAKPOINT) {
     return "lg";

--- a/src/js/images.js
+++ b/src/js/images.js
@@ -7,9 +7,28 @@ export const IMAGE_SIZES = {
   500: { width: 500, height: 625 },
 };
 
+export const stripExtension = (src) => src.split(".")[0];
+
+const getClosestSize = (targetWidth) => {
+  for (let sizeOption of Object.values(IMAGE_SIZES)) {
+    if (sizeOption.width > targetWidth) {
+      return sizeOption;
+    }
+  }
+  return IMAGE_SIZES["500"];
+};
+
+export const bucketImageLoader = ({ src, width }) => {
+  const closestSize = getClosestSize(width);
+  return `${STORAGE_URL}/${stripExtension(src)}_${closestSize.width}x${
+    closestSize.height
+  }.webp`;
+};
+
 export const getImageUrl = (src, size) => {
-  const srcWithoutExtension = src.split(".")[0];
-  return `${STORAGE_URL}/entryImages/resized/${srcWithoutExtension}_${size.width}x${size.height}.webp`;
+  return `${STORAGE_URL}/entryImages/resized/${stripExtension(src)}_${
+    size.width
+  }x${size.height}.webp`;
 };
 
 export const getEntryImageProps = (src) => {

--- a/src/js/images.js
+++ b/src/js/images.js
@@ -1,0 +1,29 @@
+import { SM_BREAKPOINT } from "../constants/breakpoints";
+import { STORAGE_URL } from "../constants/urls";
+
+export const IMAGE_SIZES = {
+  150: { width: 150, height: 150 },
+  300: { width: 300, height: 300 },
+  500: { width: 500, height: 625 },
+};
+
+export const getImageUrl = (src, size) => {
+  const srcWithoutExtension = src.split(".")[0];
+  return `${STORAGE_URL}/entryImages/resized/${srcWithoutExtension}_${size.width}x${size.height}.webp`;
+};
+
+export const getEntryImageProps = (src) => {
+  // This looks backwards, but entry images display larger by default on mobile
+  const midScreenImageUrl = getImageUrl(src, IMAGE_SIZES["150"]);
+  const mobileImageUrl = getImageUrl(src, IMAGE_SIZES["300"]);
+
+  return {
+    src: mobileImageUrl,
+    srcSet: `${midScreenImageUrl} 150w, ${mobileImageUrl} 300w`,
+    sizes: `(max-width: ${SM_BREAKPOINT}px) 300px, 150px`,
+  };
+};
+
+export const getLightboxImageProps = (src) => ({
+  src: getImageUrl(src, IMAGE_SIZES["500"]),
+});


### PR DESCRIPTION
All entry images are now stored as .webp files, with maximum sizes of 150x150, 300x300, and 500x625. This adds some logic to try to choose the proper image to request and show.