### PR TITLE
Add support for human-readable entry IDs in URL

### DIFF
--- a/functions/ejs/rss.ejs
+++ b/functions/ejs/rss.ejs
@@ -26,8 +26,8 @@
     <title type="html"><%= entry.title %></title>
     <published><%= entry.createdAt %></published>
     <updated><%= entry.updatedAt %></updated>
-    <link href="https://web3isgoinggreat.com/single/<%= entry.id %>"/> 
-    <id>https://web3isgoinggreat.com/single/<%= entry.id %></id>
+    <link href="https://web3isgoinggreat.com/single/<%= entry.readableId %>"/> 
+    <id>https://web3isgoinggreat.com/single/<%= entry.readableId %></id>
     <content type="xhtml">
       <div xmlns="http://www.w3.org/1999/xhtml">
         <% if (entry.image){%><img

--- a/functions/src/algolia.ts
+++ b/functions/src/algolia.ts
@@ -7,6 +7,7 @@ export const transformEntryForSearch = functions
     return {
       objectID: data.objectID, // Required for Algolia
       id: data.id,
+      readableId: data.readableId,
       title: data.title.replace(/<[^>]+>/gm, "").replace(/&nbsp;/g, " "),
       body: data.body.replace(/<[^>]+>/gm, "").replace(/&nbsp;/g, " "),
       date: data.date,

--- a/functions/src/algolia.ts
+++ b/functions/src/algolia.ts
@@ -7,7 +7,6 @@ export const transformEntryForSearch = functions
     return {
       objectID: data.objectID, // Required for Algolia
       id: data.id,
-      readableId: data.readableId,
       title: data.title.replace(/<[^>]+>/gm, "").replace(/&nbsp;/g, " "),
       body: data.body.replace(/<[^>]+>/gm, "").replace(/&nbsp;/g, " "),
       date: data.date,

--- a/functions/src/entries.ts
+++ b/functions/src/entries.ts
@@ -18,24 +18,3 @@ export const moveEntry = functions.https.onRequest(async (req, res) => {
   }
   res.status(400).send(`Document not located at ${req.body.currentId}`);
 });
-
-export const migrate = functions.https.onRequest(async (req, res) => {
-  const collection = await firestore.collection("entries");
-  const querySnapshot = await collection.get();
-  querySnapshot.forEach((child) => {
-    const childData = child.data() as Entry;
-    if (!childData.readableId) {
-      const strippedTitle = childData.title
-        .replace(/<[^>]+>/gm, "")
-        .replace(/&nbsp;/g, " ")
-        .replace(/\./g, "-")
-        .replace(/[^a-zA-Z0-9\- ]/g, "")
-        .toLowerCase()
-        .replace(/^(an?|the) /m, "");
-
-      const readableId = encodeURIComponent(strippedTitle.replace(/ /g, "-"));
-      child.ref.update({ readableId });
-    }
-  });
-  res.status(200).send();
-});

--- a/functions/src/entries.ts
+++ b/functions/src/entries.ts
@@ -1,6 +1,5 @@
 import { firestore } from "./config/firebase";
 import * as functions from "firebase-functions";
-import { Entry } from "./types";
 
 export const moveEntry = functions.https.onRequest(async (req, res) => {
   const collection = await firestore.collection("entries");

--- a/functions/src/rss.ts
+++ b/functions/src/rss.ts
@@ -10,7 +10,6 @@ import axios from "axios";
 
 const STORAGE_URL_PREFIX = "https://storage.googleapis.com/primary-web3";
 const STATIC_STORAGE_URL_PREFIX = "https://storage.googleapis.com/static-web3";
-
 const writeFeed = async (xml: string): Promise<void> => {
   const file = await storage.bucket("static-web3").file("rss.xml");
   await file.save(xml);

--- a/functions/src/types.ts
+++ b/functions/src/types.ts
@@ -22,7 +22,7 @@ type Link = {
 
 export type Entry = {
   id: string;
-  readableId?: string;
+  readableId: string;
   title: string;
   body: string;
   date: string;

--- a/functions/src/types.ts
+++ b/functions/src/types.ts
@@ -22,6 +22,7 @@ type Link = {
 
 export type Entry = {
   id: string;
+  readableId?: string;
   title: string;
   body: string;
   date: string;

--- a/src/components/CustomEntryHead.js
+++ b/src/components/CustomEntryHead.js
@@ -45,7 +45,7 @@ export default function CustomEntryHead({ entry, collectionDescription }) {
       <meta
         property="og:url"
         key="ogurl"
-        content={`https://web3isgoinggreat.com/single/${entry.id}`}
+        content={`https://web3isgoinggreat.com/single/${entry.readableId}`}
       />
       <meta property="og:title" key="ogtitle" content={title} />
       <meta

--- a/src/components/admin/Form.js
+++ b/src/components/admin/Form.js
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useMemo } from "react";
 
 import { signOut, upload } from "../../js/admin";
 
@@ -18,7 +18,16 @@ export default function Form() {
     text: "",
     href: "",
   });
-
+  const generatedReadableId = useMemo(
+    () =>
+      entry.title
+        .replace(/(<[^>]+>|&nbsp;)/gm, "")
+        .replace(/[^a-zA-Z0-9\- ]/g, "")
+        .toLowerCase()
+        .replace(/^(an?|the) /m, "")
+        .replace(/[. ]/g, "-"),
+    [entry.title]
+  );
   const [isUploading, setIsUploading] = useState(false);
   const [isUploadComplete, setIsUploadComplete] = useState(false);
 
@@ -63,7 +72,11 @@ export default function Form() {
 
   const save = () => {
     setIsUploading(true);
-    upload(entry, imageAttribution, entryAttribution)
+    upload(
+      { readableId: generatedReadableId, ...entry },
+      imageAttribution,
+      entryAttribution
+    )
       .then(() => {
         setIsUploadComplete(true);
         setIsUploading(false);
@@ -85,6 +98,17 @@ export default function Form() {
             id="title"
             onChange={createFieldSetter("title")}
             value={entry.title}
+          />
+        </div>
+      </div>
+      <div className="row">
+        <div className="group">
+          <label htmlFor="readableId">Readable ID: </label>
+          <textarea
+            rows={1}
+            id="readableId"
+            onChange={createFieldSetter("readableId")}
+            value={entry.readableId || generatedReadableId}
           />
         </div>
       </div>

--- a/src/components/timeline/Entry.js
+++ b/src/components/timeline/Entry.js
@@ -99,8 +99,10 @@ export default function Entry({
 
   const noJsPermalink = useMemo(
     () =>
-      router.route.startsWith("/web1") ? `#${entry.id}` : `?id=${entry.id}`,
-    [entry.id, router.route]
+      router.route.startsWith("/web1")
+        ? `#${entry.readableId}`
+        : `?id=${entry.readableId}`,
+    [entry.readableId, router.route]
   );
 
   const renderIcon = () => {
@@ -130,7 +132,7 @@ export default function Entry({
       return (
         <li>
           {showCopiedPopup && <div className="permalink-popup">Copied</div>}
-          <button onClick={() => permalink(entry.id)}>
+          <button onClick={() => permalink(entry.readableId)}>
             <i className="fas fa-link" aria-hidden={true} />
             <span className="sr-only">Permalink</span>
           </button>
@@ -179,7 +181,7 @@ export default function Entry({
     if (isBrowserRendering) {
       return (
         <h2>
-          <button onClick={() => permalink(entry.id)}>
+          <button onClick={() => permalink(entry.readableId)}>
             <span dangerouslySetInnerHTML={{ __html: entry.title }} />
           </button>
         </h2>
@@ -189,7 +191,7 @@ export default function Entry({
       return (
         <h2>
           <Link href={noJsPermalink}>
-            <a id={entry.id}>
+            <a id={entry.readableId}>
               <span dangerouslySetInnerHTML={{ __html: entry.title }} />
             </a>
           </Link>

--- a/src/components/timeline/Search.js
+++ b/src/components/timeline/Search.js
@@ -53,11 +53,15 @@ export default function Search({ filters, setSelectedEntryFromSearch }) {
       setSearchTerm(inputValue);
     },
     onSelectedItemChange: ({ selectedItem }) => {
-      setSelectedEntryFromSearch(selectedItem.id);
+      setSelectedEntryFromSearch(selectedItem.readableId);
       // Write the URL so people can permalink easily
-      router.push({ query: { ...router.query, id: selectedItem.id } }, null, {
-        shallow: true,
-      });
+      router.push(
+        { query: { ...router.query, id: selectedItem.readableId } },
+        null,
+        {
+          shallow: true,
+        }
+      );
     },
   });
 

--- a/src/components/timeline/Timeline.js
+++ b/src/components/timeline/Timeline.js
@@ -21,6 +21,7 @@ import Entry from "./Entry";
 import FixedAtBottom from "./FixedAtBottom";
 import Loader from "../Loader";
 import Error from "../Error";
+import { start } from "@popperjs/core";
 
 export default function Timeline({
   queryResult,
@@ -178,7 +179,9 @@ export default function Timeline({
                       runningScamTotal={runningScamTotal}
                       currentRunningScamTotal={currentRunningScamTotal}
                       setCurrentRunningScamTotal={setCurrentRunningScamTotal}
-                      shouldScrollToElement={entry.id === startAtId}
+                      shouldScrollToElement={
+                        entry.id === startAtId || entry.readableId == startAtId
+                      }
                       glossary={glossary}
                       collection={collection}
                       allCollections={allCollections}

--- a/src/components/timeline/Timeline.js
+++ b/src/components/timeline/Timeline.js
@@ -21,7 +21,6 @@ import Entry from "./Entry";
 import FixedAtBottom from "./FixedAtBottom";
 import Loader from "../Loader";
 import Error from "../Error";
-import { start } from "@popperjs/core";
 
 export default function Timeline({
   queryResult,

--- a/src/db/singleEntry.js
+++ b/src/db/singleEntry.js
@@ -1,12 +1,14 @@
 import { collection, getDoc, doc } from "firebase/firestore/lite";
 import { db } from "./db";
+import { getNumericId } from "./entries";
 
 export const getEntry = async (id) => {
-  if (!id.match(/\d{4}-\d{2}-\d{2}-\d{1,}/)) {
+  const numericId = await getNumericId(id);
+  if (!numericId) {
     throw new Error("invalid-argument");
   }
   const entriesCollection = collection(db, "entries");
-  const docRef = doc(entriesCollection, id);
+  const docRef = doc(entriesCollection, numericId);
   const docSnapshot = await getDoc(docRef);
 
   if (!docSnapshot.exists()) {

--- a/src/js/entry.js
+++ b/src/js/entry.js
@@ -12,6 +12,7 @@ export const EMPTY_ENTRY = {
   },
   links: [{ linkText: "", href: "", extraText: "" }],
   title: "",
+  readableId: "",
   image: { src: "", alt: "", caption: "", isLogo: false },
   scamTotal: 0,
 };
@@ -24,6 +25,7 @@ export const LinkFieldPropType = PropTypes.shape({
 
 export const EntryPropType = PropTypes.shape({
   id: PropTypes.string,
+  readableId: PropTypes.string.isRequired,
   filters: PropTypes.shape({
     theme: PropTypes.arrayOf(PropTypes.string).isRequired,
     tech: PropTypes.arrayOf(PropTypes.string),

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -39,10 +39,7 @@ export async function getServerSideProps(context) {
       });
     }
 
-    if (
-      context.query.id &&
-      context.query.id.match(/\d{4}-\d{2}-\d{2}-?\d{0,2}/)
-    ) {
+    if (context.query.id) {
       props.startAtId = context.query.id;
     }
   }


### PR DESCRIPTION
Instead of linking to `https://web3isgoinggreat.com/?id=2022-04-14-4`, permalinks will now be in the style of `https://web3isgoinggreat.com/?id=monero-holders-plan-a-bank-run`. The old style will still work for backwards-compatibility.

Closes #269 