### PR TITLE
Accessibility fixes for header

### DIFF
--- a/src/components/timeline/Header.js
+++ b/src/components/timeline/Header.js
@@ -20,6 +20,7 @@ const Header = forwardRef(function Header(
     if (clearAllFiltering && isBrowserRendering) {
       return (
         <button className={className} onClick={clearAllFiltering}>
+          <span className="sr-only">Clear timeline filters</span>
           {contents}
         </button>
       );

--- a/src/components/timeline/Header.js
+++ b/src/components/timeline/Header.js
@@ -34,7 +34,7 @@ const Header = forwardRef(function Header(
 
   const renderLinks = () => (
     <>
-      <ul>
+      <ul role="navigation" aria-label="Main">
         <li>
           <Link href="/what">
             <a>What is web3?</a>


### PR DESCRIPTION
First of all, great work on making this site very accessible. I noticed two little things that I thought I'd just open a PR for.

## No label for "clear filters" buttons in header

The Monkey logo and H1 on the header are both wrapped in a `button` that clears filters on the page. However, the content of the button does not tell you what the button does, so for a SR user it is a little confusion as to what this UI element does when you select it.

Because they have different contents, and in the name of not changing too much, I opted to add a `.sr-only` span to these buttons that reads "Clear timeline filters." Using an `aria-label` attribute would have been cleaner for the image, but it would override the `h1`'s helpful content.

On a side note, I think maaaaybe just for all users it would be better to add a "Clear" button to the filter area so everyone can see and hear a distinct button with this action.

## Navigation role for main navigation

Added `role="navigation" aria-label="Main"` to the navigation `ul` in the header.

