### PR TITLE
Wrap long words to avoid gutter on small viewports

### DIFF
--- a/src/styles/main.sass
+++ b/src/styles/main.sass
@@ -543,6 +543,9 @@ img
   z-index: 2
   pointer-events: none
 
+  code
+    word-wrap: break-word
+
   :not(p, span)
     pointer-events: auto
 


### PR DESCRIPTION
Hello! Big fan of the site. I noticed on mobile and small viewports in general, a gutter/gap on the side of the page where the long hex string in the Vanity Address article is going outside of the container. I think this will fix it. 

Tested locally with `npm dev`

Thanks!