### PR TITLE
Implement starred posts

### DIFF
--- a/functions/src/metadata.ts
+++ b/functions/src/metadata.ts
@@ -110,3 +110,11 @@ export const recalculateEntryCount = functions.https.onRequest(
     res.status(204).end();
   }
 );
+
+export const getEntryCount = functions.https.onRequest(async (req, res) => {
+  const entriesSnapshot = await firestore
+    .collection("entries")
+    .where("date", "<", "2022-01-01")
+    .get();
+  res.send({ size: entriesSnapshot.size });
+});

--- a/src/components/Checkbox.js
+++ b/src/components/Checkbox.js
@@ -1,8 +1,15 @@
+import clsx from "clsx";
 import PropTypes from "prop-types";
 
-export default function Checkbox({ checked, toggleCheckbox, id, children }) {
+export default function Checkbox({
+  checked,
+  toggleCheckbox,
+  id,
+  children,
+  className,
+}) {
   return (
-    <div className="input-group">
+    <div className={clsx("input-group", className)}>
       <input
         type="checkbox"
         id={id}
@@ -20,4 +27,5 @@ Checkbox.propTypes = {
   toggleCheckbox: PropTypes.func.isRequired,
   id: PropTypes.string.isRequired,
   children: PropTypes.node.isRequired,
+  className: PropTypes.string,
 };

--- a/src/components/timeline/Entry.js
+++ b/src/components/timeline/Entry.js
@@ -132,9 +132,8 @@ export default function Entry({
       return (
         <li>
           {showCopiedPopup && <div className="permalink-popup">Copied</div>}
-          <button onClick={() => permalink(entry.readableId)}>
+          <button onClick={() => permalink(entry.readableId)} title="Permalink">
             <i className="fas fa-link" aria-hidden={true} />
-            <span className="sr-only">Permalink</span>
           </button>
         </li>
       );
@@ -142,10 +141,24 @@ export default function Entry({
       // No JS
       return (
         <Link href={noJsPermalink}>
-          <i className="fas fa-link" aria-hidden={true} />
-          <span className="sr-only">Permalink</span>
+          <i className="fas fa-link" title="Permalink" />
         </Link>
       );
+    }
+  };
+
+  const maybeRenderStar = () => {
+    if (entry.starred) {
+      const star = (
+        <>
+          <i className="fas fa-star starred-entry" title="Starred entry"></i>
+        </>
+      );
+      if (setStarred) {
+        return <button onClick={() => setStarred(true)}>{star}</button>;
+      }
+      // Don't make the star clickable in the web1 view
+      return star;
     }
   };
 
@@ -156,12 +169,7 @@ export default function Entry({
           <time dateTime={entry.date}>{humanizeDate(entry.date)}</time>
         </span>
         <ul className="entry-link-icons">
-          {entry.starred && (
-            <button onClick={() => setStarred(true)}>
-              <i className="fas fa-star starred-entry" aria-hidden={true}></i>
-              <span className="sr-only">Starred</span>
-            </button>
-          )}
+          {maybeRenderStar()}
           {renderLinkIcon()}
           {"tweetId" in entry && (
             <li>
@@ -172,7 +180,6 @@ export default function Entry({
                 title="Tweet link"
               >
                 <i className="fa-brands fa-twitter" aria-hidden={true} />
-                <span className="sr-only">Tweet link</span>
               </a>
             </li>
           )}
@@ -427,7 +434,7 @@ Entry.propTypes = {
   glossary: PropTypes.object, // Not defined in web1
   allCollections: PropTypes.object.isRequired, // Not defined in web1
   setCollection: PropTypes.func, // Not defined in web1
-  setStarred: PropTypes.func,
+  setStarred: PropTypes.func, // Not defined in web1
 };
 
 Entry.defaultProps = {

--- a/src/components/timeline/Entry.js
+++ b/src/components/timeline/Entry.js
@@ -35,6 +35,7 @@ export default function Entry({
   collection,
   allCollections,
   setCollection,
+  setStarred,
   shouldScrollToElement,
 }) {
   const ref = useRef();
@@ -156,10 +157,10 @@ export default function Entry({
         </span>
         <ul className="entry-link-icons">
           {entry.starred && (
-            <>
+            <button onClick={() => setStarred(true)}>
               <i className="fas fa-star starred-entry" aria-hidden={true}></i>
               <span className="sr-only">Starred</span>
-            </>
+            </button>
           )}
           {renderLinkIcon()}
           {"tweetId" in entry && (
@@ -426,6 +427,7 @@ Entry.propTypes = {
   glossary: PropTypes.object, // Not defined in web1
   allCollections: PropTypes.object.isRequired, // Not defined in web1
   setCollection: PropTypes.func, // Not defined in web1
+  setStarred: PropTypes.func,
 };
 
 Entry.defaultProps = {

--- a/src/components/timeline/Filters.js
+++ b/src/components/timeline/Filters.js
@@ -10,9 +10,12 @@ import { sentenceCase } from "../../js/utilities";
 
 import Select from "react-select";
 import Search from "./Search";
+import Checkbox from "../Checkbox";
 
 export default function Filters({
   filters,
+  starred,
+  setStarred,
   setFilters,
   setSelectedEntryFromSearch,
   windowWidth,
@@ -100,6 +103,14 @@ export default function Filters({
         >
           <div className="filters-group">
             {Object.keys(FILTERS).map(renderFilterGroup)}
+            <Checkbox
+              checked={starred}
+              toggleCheckbox={() => setStarred(!starred)}
+              id="starred-filter"
+              className="inline-checkbox"
+            >
+              Starred
+            </Checkbox>
           </div>
           <div className="search-group">
             <Search
@@ -125,6 +136,8 @@ Filters.propTypes = {
     ).isRequired,
     sort: PropTypes.string.isRequired,
   }).isRequired,
+  starred: PropTypes.bool.isRequired,
+  setStarred: PropTypes.func.isRequired,
   setFilters: PropTypes.func.isRequired,
   setSelectedEntryFromSearch: PropTypes.func.isRequired,
   windowWidth: WindowWidthPropType,

--- a/src/components/timeline/Timeline.js
+++ b/src/components/timeline/Timeline.js
@@ -30,6 +30,7 @@ export default function Timeline({
   queryResult,
   collection,
   filters,
+  starred,
   glossary,
   griftTotal,
   allCollections,
@@ -37,6 +38,7 @@ export default function Timeline({
   startAtId,
   setCollection,
   setFilters,
+  setStarred,
   setSelectedEntryFromSearch,
   clearAllFiltering,
 }) {
@@ -217,6 +219,7 @@ export default function Timeline({
                       collection={collection}
                       allCollections={allCollections}
                       setCollection={setCollection}
+                      setStarred={setStarred}
                     />
                   );
 
@@ -274,6 +277,8 @@ export default function Timeline({
         <Filters
           filters={filters}
           setFilters={setFilters}
+          starred={starred}
+          setStarred={setStarred}
           setSelectedEntryFromSearch={setSelectedEntryFromSearch}
           windowWidth={windowWidth}
         />
@@ -308,6 +313,7 @@ Timeline.propTypes = {
   }),
   filters: FiltersPropType.isRequired,
   collection: PropTypes.string,
+  starred: PropTypes.bool.isRequired,
   glossary: PropTypes.object.isRequired,
   griftTotal: PropTypes.number.isRequired,
   allCollections: PropTypes.object.isRequired,
@@ -315,6 +321,7 @@ Timeline.propTypes = {
   startAtId: PropTypes.string,
   setCollection: PropTypes.func.isRequired,
   setFilters: PropTypes.func.isRequired,
+  setStarred: PropTypes.func.isRequired,
   setSelectedEntryFromSearch: PropTypes.func.isRequired,
   clearAllFiltering: PropTypes.func.isRequired,
 };

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -28,7 +28,7 @@ export async function getServerSideProps(context) {
     if (context.query.collection) {
       // Filters, starred, and collections are mutually exclusive
       props.initialFilters.collection = context.query.collection;
-    } else if (context.query.starred && Boolean(context.query.starred)) {
+    } else if (context.query.starred && context.query.starred === "true") {
       props.initialStarred = true;
     } else if (FILTER_CATEGORIES.some((filter) => filter in context.query)) {
       let hasFilterCategory = false;

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -53,6 +53,7 @@ export async function getServerSideProps(context) {
     getEntries({
       ...props.initialFilters,
       ...(props.initialStartAtId && { startAtId: props.initialStartAtId }),
+      starred: props.initialStarred,
     }),
     getGlossaryEntries(),
     getMetadata(),
@@ -131,8 +132,19 @@ export default function IndexPage({
         query[category] = filters[category].join(",");
       }
     }
-    router.push({ query }, null, { shallow: true });
-    setStarredState(false);
+
+    // We can't filter by categories AND show the starred filter, but if the only filter
+    // being applied is sorting, we can maintain the starred filter
+    if (Object.keys(query).length) {
+      router.push({ query }, null, { shallow: true });
+      setStarredState(false);
+    } else {
+      if (starred) {
+        query.starred = true;
+      }
+      router.push({ query }, null, { shallow: true });
+    }
+
     setFilterState(filters);
   };
 
@@ -146,7 +158,7 @@ export default function IndexPage({
       router.push({ query: {} }, null, { shallow: true });
     }
     setSelectedEntryFromSearch(null);
-    setFilterState(EMPTY_FILTERS_STATE);
+    setFilterState({ ...EMPTY_FILTERS_STATE, sort: filters.sort });
     setCollectionState(null);
     setStarredState(starred);
   };

--- a/src/styles/_admin.sass
+++ b/src/styles/_admin.sass
@@ -62,10 +62,6 @@
       &:not(:first-child)
         padding-left: 10px
 
-    .inline-checkbox
-      input[type="checkbox"]
-        margin-right: 5px
-
     fieldset
       display: flex
       flex-direction: column

--- a/src/styles/_filters.sass
+++ b/src/styles/_filters.sass
@@ -198,6 +198,15 @@
     margin-left: 0
     justify-content: center
 
+  .inline-checkbox
+    padding: 10px 0
+
+  .filters-group
+    border-bottom: 1px solid $timeline-line-color
+
+  .search-group
+    margin-top: 10px
+
 // Dark mode
 @mixin filtersDarkMode()
   .timeline-filter-wrapper

--- a/src/styles/_filters.sass
+++ b/src/styles/_filters.sass
@@ -22,6 +22,10 @@
 .search-with-button
   display: flex
 
+.input-group
+  display: flex
+  align-items: center
+
 .expand-filters-button,
 .sort-button
   display: flex

--- a/src/styles/main.sass
+++ b/src/styles/main.sass
@@ -141,6 +141,10 @@ footer.page-footer
   .constrain-width p
     text-align: center
 
+.inline-checkbox
+  input[type="checkbox"]
+    margin-right: 5px
+
 div.content-wrapper
   display: flex
   min-height: calc(100vh - 215px)


### PR DESCRIPTION
This implements starred posts, where entries that I mark as starred show a little star icon in the top corner. There is now a new filter to allow people to filter the timeline to only starred posts, creating a highlight reel of sorts.

As with some of the other filters, there is a limit to how much people can slice and dice. People can sort starred posts by ascending or descending, but the filter can't be combined with the other filters on theme/tech/blockchain or combined with collection views.

<img width="477" alt="Screen Shot 2022-12-31 at 11 25 27 PM" src="https://user-images.githubusercontent.com/2487900/210160973-8fe623a5-642e-4258-9f7f-1f1db855efdb.png">
